### PR TITLE
Makefile: fix for 32-bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 #
 
 OS = $(shell sh -c 'uname')
+LBITS = $(shell getconf LONG_BIT)
 
 ifeq ($(OS), Linux)
   SHARED_LIBRARY_FLAGS = -shared -fPIC
@@ -13,30 +14,37 @@ else ifeq ($(OS), Darwin)
   SHARED_LIBRARY_FLAGS = -bundle -undefined dynamic_lookup  # go figure
 endif
 
-CC = g++ -m64 -Wall -rdynamic
+CC = g++
+
+ifeq ($(LBITS),64)
+   CXXFLAGS = -m64 -Wall -rdynamic
+else
+   CXXFLAGS = -m32 -Wall -rdynamic
+endif
+
 LIBS= -lcln -lgc -ldl -lreadline -ltermcap # or -lncurses, dealer choice
 OBJS = rlstream.o stopwatch.o reader.o primops.o
 
 cl: cl.cc cl.h ${OBJS}
-	${CC} cl.cc ${OBJS} -g -o cl ${LIBS}
+	${CC} ${CXXFLAGS} cl.cc ${OBJS} -g -o cl ${LIBS}
 
 clo: cl.cc cl.h ${OBJS}
-	${CC} -O2 cl.cc ${OBJS} -o clo ${LIBS}
+	${CC} ${CXXFLAGS} -O2 cl.cc ${OBJS} -o clo ${LIBS}
 
 primops.o: primops.cc cl.h
-	${CC} -O2 -c primops.cc
+	${CC} ${CXXFLAGS} -O2 -c primops.cc
 
 reader.o: reader.cc reader.h cl.h rlstream.h
-	${CC} -O2 -c reader.cc
+	${CC} ${CXXFLAGS} -O2 -c reader.cc
 
 rlstream.o: rlstream.cc rlstream.h
-	${CC} -O2 -c rlstream.cc -DUSE_GNU_READLINE
+	${CC} ${CXXFLAGS} -O2 -c rlstream.cc -DUSE_GNU_READLINE
 
 stopwatch.o: stopwatch.cc stopwatch.h
-	${CC} -O2 -c stopwatch.cc
+	${CC} ${CXXFLAGS} -O2 -c stopwatch.cc
 
 fftest: fftest.cc cl.h
-	${CC} $(SHARED_LIBRARY_FLAGS) -o fftest fftest.cc
+	${CC} ${CXXFLAGS} $(SHARED_LIBRARY_FLAGS) -o fftest fftest.cc
 
 test:
 	time ./cl<testdata


### PR DESCRIPTION
This just fixes Makefile for 32-bit platforms. Apparently macOS needs additional fix-up, since currently linking fails.